### PR TITLE
Fix contact info for Antiy-AVL and Avast

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ When contributing an email template to the repository you can use [Mailto link g
 | AhnLab-V3 | v3sos<span>@</span>ahnlab.com (recommended), e-support<span>@</span>ahnlab.com, samples<span>@</span>ahnlab.com | [Send Report](vendors/AhnLab-V3.md) | No |
 | Alibaba | virustotal<span>@</span>list.alibaba-inc.com | [Send Report](vendors/Alibaba.md) | No | 
 | ALYac (ESTsecurity) | esrc<span>@</span>estsecurity.com | | |
-| Antiy-AVL | avlsdk_support_vt<span>@</span>antiy.cn | | |
-| Avast | virus<span>@</span>avast.com | | |
+| Antiy-AVL | avlsdk_support_vt<span>@</span>antiy.cn or submit<span>@</span>antiy.com | | |
+| Avast | https://www.avast.com/false-positive-file-form.php, virus<span>@</span>avast.com | | |
 | Avira (no cloud) | cleanset<span>@</span>avira.com, virus_malware<span>@</span>avira.com, virus<span>@</span>avira.com | | |
 | AVG | https://www.avg.com/false-positive-file-form, https://www.avg.com/us-en/whitelist | | |
 | Babable | obu<span>@</span>babable.com | | |


### PR DESCRIPTION
Recovered accidentally deleted contact information in PR https://github.com/yaronelh/False-Positive-Center/pull/6 for Antiy-AVL and Avast.