### PR TITLE
Remove two bad emails for Avira

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Quote from [this VirusTotal Q&A](https://support.virustotal.com/hc/en-us/article
 | ALYac (ESTsecurity) | esrc@estsecurity.com |
 | Antiy-AVL | support@antiy.cn or [avlsdk_support_vt@antiy.cn](avlsdk_support_vt@antiy.cn) (Might not work anymore) |
 | Avast | https://www.avast.com/false-positive-file-form.php, virus@avast.com |
-| Avira (no cloud) | https://www.avira.com/en/analysis/submit, cleanset@avira.com, virus_malware@avira.com, virus@avira.com |
+| Avira (no cloud) | https://www.avira.com/en/analysis/submit, virus@avira.com |
 | AVG | https://www.avg.com/false-positive-file-form, https://www.avg.com/us-en/whitelist |
 | Babable | obu@babable.com |
 | Baidu | bav@baidu.com, gaoyingchun@baidu.com |


### PR DESCRIPTION
For the email cleanset@avira.com, I got a bounce-back email stating the following:

> Your message to cleanset@avira.com couldn't be delivered.
> cleanset wasn't found at avira.com.

Screenshot:

![image](https://github.com/yaronelh/False-Positive-Center/assets/3742859/7d94acf9-58bf-416b-a5f5-f681c201fba5)

For the email virus_malware@avira.com, I got a bounce-back email stating the following:

> This inbox is not monitored
> You replied to an email used for outbound communication to Avira customers.

Screenshot:

![image](https://github.com/yaronelh/False-Positive-Center/assets/3742859/5f916bc7-e746-40b7-81bd-ad673c8a0932)

This PR is to remove both emails.