### PR TITLE
Update G Data Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Quote from [this VirusTotal Q&A](https://support.virustotal.com/hc/en-us/article
 | Filseclab | fp@filseclab.com |
 | Forcepoint (websense) | suggest@forcepoint.com or https://support.forcepoint.com/s/article/000012884, [File Submission Tool](https://support.forcepoint.com/s/article/000019083), [URL Submission Tool](https://support.forcepoint.com/s/article/URL-List-submission-Tool) |
 | Fortinet | submitvirus@fortinet.com, https://www.fortiguard.com/faq/classificationdispute |
-| GData | https://www.gdatasoftware.com/faq/consumer/submit-a-suspicious-file-app-or-url |
+| GData | https://www.gdata.de/help/en/general/AllgemeineFragen/DateiURLAppEinsenden |
 | Gridinsoft | antimalware@gridinsoft.com, https://gridinsoft.com/incorrect-detection | 
 | Hacksoft | virus@hacksoft.com.pe |
 | Hauri | viruslab@hauri.co.kr |


### PR DESCRIPTION
The current url for G Data no longer works, and falls back on the documentation homepage. From what I can tell, this is the new correct url

https://www.gdata.de/help/en/general/AllgemeineFragen/DateiURLAppEinsenden/ :

![image](https://github.com/yaronelh/False-Positive-Center/assets/19509185/e01ae504-ce04-4300-8f1f-61cd9a84b240)
